### PR TITLE
bridge=viaduct → bridge: true

### DIFF
--- a/process.lua
+++ b/process.lua
@@ -609,7 +609,7 @@ function toTunnelBool(tunnel, covered)
 end
 
 function toBridgeBool(bridge)
-	if bridge == "yes" then
+	if bridge == "yes" or bridge == "viaduct" then
 		return true
 	end
 	return false

--- a/process.lua
+++ b/process.lua
@@ -609,7 +609,7 @@ function toTunnelBool(tunnel, covered)
 end
 
 function toBridgeBool(bridge)
-	if bridge == "yes" or bridge == "viaduct" then
+	if bridge == "yes" or bridge == "viaduct" or bridge == "boardwalk" or bridge == "cantilever" or bridge == "covered" or bridge == "low_water_crossing" or bridge == "movable" or bridge == "trestle" then
 		return true
 	end
 	return false


### PR DESCRIPTION
treat ways tagged with bridge=viaduct as bridges
otherwise they end up below bridges polygons

![example](https://imgur.com/ATVgUoE.png)
